### PR TITLE
Use accelerometer crate's Accelerometer trait and I16x3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/japaric/lsm303dlhc"
 version = "0.2.0"
 
 [dependencies]
+accelerometer = "0.5"
 embedded-hal = "0.2.0"
 generic-array = "0.11.0"
 


### PR DESCRIPTION
Impls the `accelerometer` crate's `Accelerometer` trait for reading accelerometer data, and imports the `I16x3` type from it as well.

This allows for generic reuse of accelerometer data consuming crates which work across various accelerometer drivers.